### PR TITLE
SERVER: load from fatjar

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,9 +83,13 @@
                     "default": 11451,
                     "description": "The port number which the language server listens on."
                 },
-                "aya.lsp.path": {
+                "aya.lsp.exec": {
                     "type": "string",
-                    "description": "Specifies the local path of the aya language server, mostly used for debugging"
+                    "description": "Specifies the local path of the aya language server executable, mostly used for debugging"
+                },
+                "aya.lsp.fatJar": {
+                    "type": "string",
+                    "description": "Specifies the local path of the fatjar of the aya language server"
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -83,13 +83,9 @@
                     "default": 11451,
                     "description": "The port number which the language server listens on."
                 },
-                "aya.lsp.exec": {
+                "aya.lsp.path": {
                     "type": "string",
-                    "description": "Specifies the local path of the aya language server executable, mostly used for debugging"
-                },
-                "aya.lsp.fatJar": {
-                    "type": "string",
-                    "description": "Specifies the local path of the fatjar of the aya language server"
+                    "description": "Specifies the local path of the aya language server executable or fatjar, mostly used for debugging"
                 }
             }
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,9 +1,10 @@
 import * as vscode from 'vscode';
 import * as daemon from './server-daemon';
+import * as find from './find';
 
 export async function activate(context: vscode.ExtensionContext) {
-  let lspJar = await daemon.findAya(context);
-  if (lspJar === null) return;
+  let lspLoadPath = await find.findAya(context);
+  if (lspLoadPath === null) return;
 
   const initTasks: PromiseLike<void>[] = [];
 
@@ -12,7 +13,7 @@ export async function activate(context: vscode.ExtensionContext) {
     cancellable: false,
     title: "Loading Aya library",
   }, async progress => {
-    await daemon.startDaemon(context, lspJar!, progress);
+    await daemon.startDaemon(context, lspLoadPath!, progress);
     return new Promise(resolve => setTimeout(resolve, 5000));
   }));
 

--- a/src/find.ts
+++ b/src/find.ts
@@ -11,15 +11,7 @@ export async function findAya(context: vscode.ExtensionContext): Promise<string 
     await vscode.window.showInformationMessage("Aya language server is disabled");
     return null;
   }
-  /*
-    let lspFatJarPath = config.get<string>("lsp.fatJar");
-    let lspExecPath = config.get<string>("lsp.exec");
-    if (lspFatJarPath && await os_utils.fsExists(lspFatJarPath)) {
-      return lspFatJarPath;
-    } else if (lspExecPath && await os_utils.fsExists(lspExecPath)) {
-      return lspExecPath;
-    }
-  */
+
   let lspLoadPath = config.get<string>("lsp.path");
   if (lspLoadPath && await os_utils.fsExists(lspLoadPath)) {
     return lspLoadPath;

--- a/src/find.ts
+++ b/src/find.ts
@@ -11,13 +11,18 @@ export async function findAya(context: vscode.ExtensionContext): Promise<string 
     await vscode.window.showInformationMessage("Aya language server is disabled");
     return null;
   }
-
-  let lspFatJarPath = config.get<string>("lsp.fatJar");
-  let lspExecPath = config.get<string>("lsp.exec");
-  if (lspFatJarPath && fs.existsSync(lspFatJarPath)) {
-    return lspFatJarPath;
-  } else if (lspExecPath && fs.existsSync(lspExecPath)) {
-    return lspExecPath;
+  /*
+    let lspFatJarPath = config.get<string>("lsp.fatJar");
+    let lspExecPath = config.get<string>("lsp.exec");
+    if (lspFatJarPath && await os_utils.fsExists(lspFatJarPath)) {
+      return lspFatJarPath;
+    } else if (lspExecPath && await os_utils.fsExists(lspExecPath)) {
+      return lspExecPath;
+    }
+  */
+  let lspLoadPath = config.get<string>("lsp.path");
+  if (lspLoadPath && await os_utils.fsExists(lspLoadPath)) {
+    return lspLoadPath;
   }
 
   const sysPath = process.env['PATH'];

--- a/src/find.ts
+++ b/src/find.ts
@@ -1,0 +1,84 @@
+import * as fs from "fs";
+import * as vscode from "vscode";
+import * as path from "path";
+import * as os_utils from './os-utils';
+
+
+export async function findAya(context: vscode.ExtensionContext): Promise<string | null> {
+  const config = vscode.workspace.getConfiguration("aya");
+
+  if (!config.get<boolean>("lsp.enabled")) {
+    await vscode.window.showInformationMessage("Aya language server is disabled");
+    return null;
+  }
+
+  let lspFatJarPath = config.get<string>("lsp.fatJar");
+  let lspExecPath = config.get<string>("lsp.exec");
+  if (lspFatJarPath && fs.existsSync(lspFatJarPath)) {
+    return lspFatJarPath;
+  } else if (lspExecPath && fs.existsSync(lspExecPath)) {
+    return lspExecPath;
+  }
+
+  const sysPath = process.env['PATH'];
+  if (sysPath) {
+    const pathParts = sysPath.split(path.delimiter);
+    for (const pathPart of pathParts) {
+      const binPath = path.join(pathPart, os_utils.isWindows() ? "aya-lsp.bat" : "aya-lsp");
+      if (fs.existsSync(binPath)) {
+        return binPath;
+      }
+    }
+  }
+
+  await vscode.window.showWarningMessage("Cannot find aya language server");
+  return null;
+}
+
+export async function findJavaExecutable(rawBinName: string): Promise<string> {
+  const binName = os_utils.correctBinName(rawBinName);
+
+  // First search java.home setting
+  const userJavaHome = vscode.workspace.getConfiguration('java').get('home') as string;
+
+  if (userJavaHome) {
+    let candidate = await findJavaExecutableInJavaHome(userJavaHome, binName);
+    if (candidate)
+      return candidate;
+  }
+
+  // Then search each JAVA_HOME
+  const envJavaHome = process.env['JAVA_HOME'];
+
+  if (envJavaHome) {
+    const candidate = await findJavaExecutableInJavaHome(envJavaHome, binName);
+    if (candidate)
+      return candidate;
+  }
+
+  const sysPath = process.env['PATH'];
+  // Then search PATH parts
+  if (sysPath) {
+    const pathParts = sysPath.split(path.delimiter);
+    for (const pathPart of pathParts) {
+      const binPath = path.join(pathPart, binName);
+      if (fs.existsSync(binPath)) {
+        return binPath;
+      }
+    }
+  }
+
+  return binName;
+}
+
+async function findJavaExecutableInJavaHome(javaHome: string, binName: string): Promise<string | null> {
+  const workspaces = javaHome.split(path.delimiter);
+
+  for (const workspace of workspaces) {
+    const binPath = path.join(workspace, 'bin', binName);
+
+    if (await os_utils.fsExists(binPath))
+      return binPath;
+  }
+  return null;
+}

--- a/src/os-utils.ts
+++ b/src/os-utils.ts
@@ -1,0 +1,37 @@
+/*
+ * See https://github.com/fwcd/vscode-kotlin/blob/master/src/util/osUtils.ts
+ */
+
+import * as fs from 'fs';
+
+export function isWindows(): boolean {
+  return process.platform === "win32";
+}
+
+const UNIXOIDS = new Set([
+  "linux",
+  "darwin",
+  "freebsd",
+  "openbsd"
+]);
+
+export function isUnixoid(): boolean {
+  return process.platform in UNIXOIDS;
+}
+
+export function correctBinName(binName: string): string {
+  return `${binName}${isWindows() ? '.exe' : ''}`;
+}
+
+export function correctScriptName(binName: string): string {
+  return `${binName}${isWindows() ? '.bat' : ''}`;
+}
+
+export async function fsExists(path: fs.PathLike): Promise<boolean> {
+  try {
+    await fs.promises.access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/server-daemon.ts
+++ b/src/server-daemon.ts
@@ -1,31 +1,40 @@
-import * as fs from 'fs';
 import * as net from "net";
-import * as path from "path";
 import * as vscode from 'vscode';
+import * as path from "path";
 import * as child_process from "child_process";
 import * as features from './features';
 
+
 import { LanguageClientOptions, RevealOutputChannelOn } from "vscode-languageclient";
 import { LanguageClient, ServerOptions, StreamInfo } from "vscode-languageclient/node";
+import { findJavaExecutable } from "./find";
 
 type Progress = vscode.Progress<{ message?: string; increment?: number }>;
 
-export async function startDaemon(context: vscode.ExtensionContext, lspExec: string, progress: Progress) {
+export async function startDaemon(context: vscode.ExtensionContext, lspLoadPath: string, progress: Progress) {
   progress.report({ message: "Starting Aya", increment: 500 });
   const config = vscode.workspace.getConfiguration("aya");
 
   const outputChannel = vscode.window.createOutputChannel("Aya");
   context.subscriptions.push(outputChannel);
-  outputChannel.appendLine(`Aya Language Server: ${lspExec}`);
+  outputChannel.appendLine(`Aya Language Server: ${lspLoadPath}`);
 
   let mode: string = config.get<string>("lsp.mode") ?? "client";
   let port: number = config.get<number>("lsp.port") ?? 11451;
   let host: string = config.get<string>("lsp.host") ?? "localhost";
 
   let serverOptions: ServerOptions;
-  if (mode === "server") serverOptions = runServer(outputChannel, lspExec, host, port);
-  else if (mode === "client") serverOptions = runClient(host, port);
-  else serverOptions = runDebug(outputChannel, lspExec);
+  let extname = path.extname(lspLoadPath);
+  if (extname === ".jar") {
+    let javaPath = await findJavaExecutable("java");
+    if (mode === "server") serverOptions = runServerFatJar(outputChannel, lspLoadPath, host, port, javaPath);
+    else if (mode === "client") serverOptions = runClient(host, port);
+    else serverOptions = runDebugFatJar(outputChannel, lspLoadPath, javaPath);
+  } else {
+    if (mode === "server") serverOptions = runServer(outputChannel, lspLoadPath, host, port);
+    else if (mode === "client") serverOptions = runClient(host, port);
+    else serverOptions = runDebug(outputChannel, lspLoadPath);
+  }
 
   let languageClient = createLanguageClient(serverOptions);
   let languageClientDisposable = languageClient.start();
@@ -48,16 +57,25 @@ export async function startDaemon(context: vscode.ExtensionContext, lspExec: str
   features.setupAyaSpecialFeatures(context, languageClient);
 }
 
-function runDebug(outputChannel: vscode.OutputChannel, lspExec: string): ServerOptions {
+function runDebugFatJar(outputChannel: vscode.OutputChannel, lspLoadPath: string, javaPath: string): ServerOptions {
   return () => new Promise((resolve, reject) => {
-    const proc = spawnJava(outputChannel, lspExec, ["--mode", "debug"]);
+    const proc = spawnFatJar(outputChannel, lspLoadPath, ["--enable-preview", "-jar", "--mode", "debug"], javaPath);
     proc.on("exit", (code, sig) => outputChannel.appendLine(`The language server exited with ${code} (${sig})`));
     proc.on("error", reject);
     proc.on("spawn", () => resolve(proc));
   });
 }
 
-function runServer(outputChannel: vscode.OutputChannel, lspExec: string, host: string, port: number): ServerOptions {
+function runDebug(outputChannel: vscode.OutputChannel, lspLoadPath: string): ServerOptions {
+  return () => new Promise((resolve, reject) => {
+    const proc = spawnExec(outputChannel, lspLoadPath, ["--mode", "debug"]);
+    proc.on("exit", (code, sig) => outputChannel.appendLine(`The language server exited with ${code} (${sig})`));
+    proc.on("error", reject);
+    proc.on("spawn", () => resolve(proc));
+  });
+}
+
+function runServerFatJar(outputChannel: vscode.OutputChannel, lspLoadPath: string, host: string, port: number, javaPath: string): ServerOptions {
   return () => new Promise((resolve, reject) => {
     const server = net.createServer(socket => {
       server.close();
@@ -65,14 +83,41 @@ function runServer(outputChannel: vscode.OutputChannel, lspExec: string, host: s
     });
     server.listen(port, host, () => {
       const tcpPort = (server.address() as net.AddressInfo).port.toString();
-      spawnJava(outputChannel, lspExec, ["--mode", "client", "--port", tcpPort]);
+      spawnFatJar(outputChannel, lspLoadPath, ["--enable-preview", "-jar", "--mode", "client", "--port", tcpPort], javaPath);
     });
     server.on("error", reject);
   });
 }
 
-function spawnJava(outputChannel: vscode.OutputChannel, lspExec: string, args: string[]): child_process.ChildProcess {
-  const proc = child_process.spawn(lspExec, args);
+function runServer(outputChannel: vscode.OutputChannel, lspLoadPath: string, host: string, port: number): ServerOptions {
+  return () => new Promise((resolve, reject) => {
+    const server = net.createServer(socket => {
+      server.close();
+      resolve({ reader: socket, writer: socket });
+    });
+    server.listen(port, host, () => {
+      const tcpPort = (server.address() as net.AddressInfo).port.toString();
+      spawnExec(outputChannel, lspLoadPath, ["--mode", "client", "--port", tcpPort]);
+    });
+    server.on("error", reject);
+  });
+}
+
+function spawnFatJar(outputChannel: vscode.OutputChannel, lspLoadPath: string, args: string[], javaPath: string): child_process.ChildProcess {
+  args.splice(2, 0, lspLoadPath);
+
+  const proc = child_process.spawn(javaPath, args);
+
+  const outputCallback = (data: any) => outputChannel.append(`${data}`);
+  proc.stdout.on("data", outputCallback);
+  proc.stderr.on("data", outputCallback);
+
+  proc.on("exit", (code, sig) => outputChannel.appendLine(`The language server exited with ${code} (${sig})`));
+  return proc;
+}
+
+function spawnExec(outputChannel: vscode.OutputChannel, lspLoadPath: string, args: string[]): child_process.ChildProcess {
+  const proc = child_process.spawn(lspLoadPath, args);
 
   const outputCallback = (data: any) => outputChannel.append(`${data}`);
   proc.stdout.on("data", outputCallback);
@@ -109,36 +154,4 @@ function createLanguageClient(serverOptions: ServerOptions): LanguageClient {
   };
 
   return new LanguageClient("aya", "Aya language client", serverOptions, clientOptions);
-}
-
-export async function findAya(context: vscode.ExtensionContext): Promise<string | null> {
-  const config = vscode.workspace.getConfiguration("aya");
-
-  if (!config.get<boolean>("lsp.enabled")) {
-    await vscode.window.showInformationMessage("Aya language server is disabled");
-    return null;
-  }
-
-  let lspExec = config.get<string>("lsp.path");
-  if (lspExec && fs.existsSync(lspExec)) {
-    return lspExec;
-  }
-
-  const sysPath = process.env['PATH'];
-  if (sysPath) {
-    const pathParts = sysPath.split(path.delimiter);
-    for (const pathPart of pathParts) {
-      const binPath = path.join(pathPart, isWindows() ? "aya-lsp.bat" : "aya-lsp");
-      if (fs.existsSync(binPath)) {
-        return binPath;
-      }
-    }
-  }
-
-  await vscode.window.showWarningMessage("Cannot find aya language server");
-  return null;
-}
-
-export function isWindows(): boolean {
-  return process.platform === "win32";
 }


### PR DESCRIPTION
Now user provides the absolute path of `aya-*-fat.jar` or `aya-lsp` executable in the settings of Aya Language Server extension.

if `Fat Jar` exists, Aya Language Server is loaded from `aya-*-fat.jar`, which is by default;
else if `Exec` exists,  Aya Language Server is loaded from `aya-lsp` executable;
else Aya Language Server is not found.

Users can comment `"aya.lsp.exec"` or `"aya.lsp.fatJar"` in `settings.json` to decide where Aya Language Server is loaded from.